### PR TITLE
[LCA-16] Creation of  `ForgotPassword` page with token control logic

### DIFF
--- a/src/app/(private)/dashboard/page.tsx
+++ b/src/app/(private)/dashboard/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { Box, Button, Container, Heading, Text } from '@chakra-ui/react';
+import { signOut, useSession } from 'next-auth/react';
+import Image from 'next/image';
+
+function Dashboard() {
+  const session = useSession();
+  const { user } = session.data || {};
+
+  return (
+    <Container
+      display='flex'
+      flexDirection='column'
+      alignItems='center'
+      justifyContent='center'
+      minHeight='80vh'
+      textAlign='center'
+    >
+      <Heading as='h1' size='2xl' mb={4}>
+        Welcome to ChatApp, {user?.name}!
+      </Heading>
+      <Text mb={2}>
+        We are currently working on this page. Soon there will be new features available!
+      </Text>
+      <Box mt={4}>
+        {user?.image && (
+          <Image
+            src={user.image}
+            alt='User Profile Picture'
+            width={100}
+            height={100}
+            style={{ borderRadius: '50%' }}
+          />
+        )}
+      </Box>
+      <Box mt={4}>
+        <Text fontSize='md'>
+          <strong>Name:</strong> {user?.name || 'N/A'}
+        </Text>
+        <Text fontSize='md'>
+          <strong>Email:</strong> {user?.email || 'N/A'}
+        </Text>
+      </Box>
+
+      {/* Sign Out Button */}
+      <Box mt={4}>
+        <Button onClick={() => signOut()}>Sign Out</Button>
+      </Box>
+    </Container>
+  );
+}
+
+export default Dashboard;

--- a/src/app/(public)/forgot-password/page.tsx
+++ b/src/app/(public)/forgot-password/page.tsx
@@ -1,0 +1,16 @@
+import { ForgotPasswordForm } from '@/features/auth/components/ForgotPasswordForm';
+import { ResetPasswordForm } from '@/features/auth/components/ResetPasswordForm';
+
+interface PageProps {
+  searchParams: Promise<{ token?: string }>;
+}
+
+export default async function ForgotPassword({ searchParams }: PageProps) {
+  const { token } = await searchParams;
+
+  if (token) {
+    return <ResetPasswordForm token={token} />;
+  }
+
+  return <ForgotPasswordForm />;
+}

--- a/src/features/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/features/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Field, Link } from '@/components';
+import { sendResetPasswordEmail } from '@/features/auth/actions/auth.actions';
+import { FormContainer, FormFeedback, FormTitle } from '@/features/auth/components/common';
+import { Feedback } from '@/features/auth/components/common/FormFeedback';
+import translations from '@/features/auth/i18n';
+import { useForm, useTranslations } from '@/features/common/hooks';
+import { Button, Input } from '@chakra-ui/react';
+import { useState } from 'react';
+
+interface ForgotPasswordFormValues {
+  email: string;
+}
+
+function ForgotPasswordForm() {
+  const { t } = useTranslations(translations, 'auth', 'forgotPassword', 'forgot');
+  const [feedback, setFeedback] = useState<Feedback>(null);
+
+  const { values, errors, loading, handleChange, handleSubmit } = useForm<ForgotPasswordFormValues>(
+    { initialValues: { email: '' }, onSubmit }
+  );
+
+  async function onSubmit(values: ForgotPasswordFormValues) {
+    const { email } = values;
+
+    try {
+      sendResetPasswordEmail(email);
+      setFeedback({
+        message: t('Check your email to reset your password.', 'feedback.emailVerification'),
+        status: 'success',
+      });
+    } catch (error) {
+      setFeedback({ message: (error as Error).message, status: 'error' });
+    }
+  }
+
+  return (
+    <FormContainer>
+      <FormTitle>{t('Recover password', 'form.title')}</FormTitle>
+      <FormFeedback feedback={feedback} onClose={() => setFeedback(null)} />
+
+      <Field
+        label={t('Email', 'form.fields.email.label')}
+        errorText={errors.email}
+        invalid={!!errors.email}
+      >
+        <Input
+          name='email'
+          value={values.email}
+          onChange={handleChange}
+          placeholder={t('your.email@example.com', 'form.fields.email.placeholder')}
+          autoComplete='email'
+        />
+      </Field>
+
+      <Button w='full' onClick={handleSubmit} loading={loading} fontWeight='bold' mt='5'>
+        {t('Send recovery link', 'form.submit')}
+      </Button>
+
+      <Link color='blue.500' href='/login' fontSize='sm' mt='3'>
+        {t('Back to login', 'linkToLogin')}
+      </Link>
+    </FormContainer>
+  );
+}
+
+export default ForgotPasswordForm;

--- a/src/features/auth/components/ForgotPasswordForm/index.ts
+++ b/src/features/auth/components/ForgotPasswordForm/index.ts
@@ -1,0 +1,1 @@
+export { default as ForgotPasswordForm } from './ForgotPasswordForm';

--- a/src/features/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/src/features/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Field, Link } from '@/components';
+import { FormContainer, FormFeedback, FormTitle } from '@/features/auth/components/common';
+import { Feedback } from '@/features/auth/components/common/FormFeedback';
+import translations from '@/features/auth/i18n';
+import { useForm, useTranslations } from '@/features/common/hooks';
+import { Box, Button, Input } from '@chakra-ui/react';
+import { redirect } from 'next/navigation';
+import { useState } from 'react';
+import { resetPassword } from '../../actions/auth.actions';
+import FormPasswordRequirements from '../common/FormPasswordRequirements';
+import { validateResetPasswordForm } from './validations';
+
+export interface ResetPasswordFormValues {
+  password: string;
+  confirmPassword: string;
+}
+
+function ResetPasswordForm({ token }: { token: string }) {
+  const { t } = useTranslations(translations, 'auth', 'forgotPassword', 'reset');
+  const [showRequirements, setShowRequirements] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+
+  const { values, errors, loading, handleChange, handleSubmit, resetForm } =
+    useForm<ResetPasswordFormValues>({
+      initialValues: { password: '', confirmPassword: '' },
+      onSubmit,
+      validate: (values) => validateResetPasswordForm(values, t),
+    });
+
+  async function onSubmit(values: ResetPasswordFormValues) {
+    const { password } = values;
+
+    try {
+      resetPassword(token, password).then(() => setTimeout(() => redirect('/login'), 2000));
+      resetForm();
+      setFeedback({
+        message: t('Your password has been reset successfully.', 'feedback.passwordReset'),
+        status: 'success',
+      });
+    } catch (error) {
+      setFeedback({ message: (error as Error).message, status: 'error' });
+    }
+  }
+
+  return (
+    <FormContainer>
+      <FormTitle>{t('Reset your password', 'form.title')}</FormTitle>
+
+      <FormFeedback feedback={feedback} onClose={() => setFeedback(null)} />
+
+      {/* PASSWORD */}
+      <Box w='full'>
+        <Field
+          label={t('Password', 'form.fields.password.label')}
+          errorText={errors.password}
+          invalid={!!errors.password}
+        >
+          <Input
+            type='password'
+            name='password'
+            value={values.password}
+            onChange={handleChange}
+            onFocus={() => setShowRequirements(true)}
+            onBlur={() => setShowRequirements(false)}
+          />
+        </Field>
+        <FormPasswordRequirements show={showRequirements} password={values.password} />
+      </Box>
+
+      {/* CONFIRM PASSWORD */}
+      <Field
+        label={t('Confirm Password', 'form.fields.confirmPassword.label')}
+        errorText={errors.confirmPassword}
+        invalid={!!errors.confirmPassword}
+      >
+        <Input
+          type='password'
+          name='confirmPassword'
+          value={values.confirmPassword}
+          onChange={handleChange}
+        />
+      </Field>
+
+      <Button w='full' onClick={handleSubmit} loading={loading} fontWeight='bold' mt='5'>
+        {t('Cambiar contraseña', 'form.submit')}
+      </Button>
+
+      <Link color='blue.500' href='/login' fontSize='sm' mt='3'>
+        {t('Back to login', 'linkToLogin')}
+      </Link>
+    </FormContainer>
+  );
+}
+
+export default ResetPasswordForm;

--- a/src/features/auth/components/ResetPasswordForm/index.ts
+++ b/src/features/auth/components/ResetPasswordForm/index.ts
@@ -1,0 +1,1 @@
+export { default as ResetPasswordForm } from './ResetPasswordForm';

--- a/src/features/auth/components/ResetPasswordForm/validations.ts
+++ b/src/features/auth/components/ResetPasswordForm/validations.ts
@@ -1,0 +1,48 @@
+import translations from '@/features/auth/i18n';
+import { passwordRequirements } from '../common/FormPasswordRequirements';
+import { ResetPasswordFormValues } from './ResetPasswordForm';
+
+// RESET PASSWORD FORM VALIDATION
+type ResetPasswordKeys = ScopedKey<typeof translations, ['auth', 'forgotPassword', 'reset']>;
+
+type ValidationRule<T, KeysScope> = {
+  field: keyof T;
+  text: string;
+  key: TranslationKey<KeysScope>;
+  test: (values: T) => boolean;
+};
+
+const rules: ValidationRule<ResetPasswordFormValues, ResetPasswordKeys>[] = [
+  {
+    field: 'password',
+    text: 'Password is required',
+    key: 'form.errors.password.required',
+    test: ({ password }) => !!password,
+  },
+  {
+    field: 'password',
+    text: 'Password does not meet requirements',
+    key: 'form.errors.password.requirements',
+    test: ({ password }) => passwordRequirements.every((req) => req.test(password)),
+  },
+  {
+    field: 'confirmPassword',
+    text: 'Passwords do not match',
+    key: 'form.errors.password.mismatch',
+    test: ({ password, confirmPassword }) => !!confirmPassword && password === confirmPassword,
+  },
+];
+
+export function validateResetPasswordForm(
+  form: ResetPasswordFormValues,
+  t: Translator<ResetPasswordKeys>
+) {
+  type Errors = Partial<Record<keyof ResetPasswordFormValues, string>>;
+
+  return rules.reduce<Errors>((errors, { field, text, key, test }) => {
+    if (!test(form)) {
+      errors[field] = t(text, key);
+    }
+    return errors;
+  }, {});
+}


### PR DESCRIPTION
## Jira Ticket
[LCA-16](https://alphenx.atlassian.net/browse/LCA-16)

## What type of PR is this? (check all applicable)

- [x] 🚀 Feature
- [ ] 🧑‍💻 Refactor
- [ ] 🐛 Bug Fix
- [ ] 🎨 Style
- [ ] ✅ Test

## Description

This PR **adds** the `ForgotPassword` page with token control logic and related components.

## What has been done?

- Added `ForgotPasswordForm` to handle the forgot password flow initialization.
- Added `ResetPasswordForm` with validations.
- Implemented the `ForgotPassword` page.
- Added a provisional `Dashboard` page.


## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Related Tickets & Documents

<!-- Link to the Jira ticket or document related to this PR -->



[LCA-16]: https://alphenx.atlassian.net/browse/LCA-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ